### PR TITLE
fix newline echoing in install.sh

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -107,7 +107,9 @@ fi
 
 if [ $group_ok -eq 0 ]; then
     echo
-    echo "Setting global read and write permissions to directories\n    \"$work_dir_abs/\" and\n    \"$data_dir_abs/\""
+    echo "Setting global read and write permissions to directories"
+    echo "    \"$work_dir_abs/\" and"
+    echo "    \"$data_dir_abs/\""
     echo "(you may wish to consider fixing this manually)"
     chmod -R 777 $data_dir_abs $work_dir_abs
 fi


### PR DESCRIPTION
install.sh calls echo with \n without using the -e option. This makes
it print \n verbatim instead of printing actual newline characters.
In this case, instead of adding -e to the problematic echo, I split
the calls up into multiple ones and removed the explicit \n so that
the source looks more like what will be printed to the user.
