### PR TITLE
fix cgi parameter handling in testserver

### DIFF
--- a/testserver.py
+++ b/testserver.py
@@ -13,6 +13,7 @@ from CGIHTTPServer import CGIHTTPRequestHandler
 #   a choice if we want to emulate the super-class is_cgi method.
 from CGIHTTPServer import _url_collapse_path_split
 from sys import stderr
+from urlparse import urlparse
 
 # Note: The only reason that we sub-class in order to pull is the stupid
 #   is_cgi method that assumes the usage of specific CGI directories, I simply
@@ -20,7 +21,7 @@ from sys import stderr
 class BRATCGIHTTPRequestHandler(CGIHTTPRequestHandler):
     def is_cgi(self):
         # Having a CGI suffix is really a big hint of being a CGI script.
-        if self.path.endswith('.cgi'):
+        if urlparse(self.path).path.endswith('.cgi'):
             self.cgi_info = _url_collapse_path_split(self.path)
             return True
         else:


### PR DESCRIPTION
`testserver.py` attempts to guess whether it should serve the results of
a request as plain text or through CGI. The current guessing method
erroneously looks for `.cgi` at the end of the full url. This fails on
any request that involves GET parameters:
- http://mytestserver/ajax.cgi correctly returns json
- http://mytestserver/ajax.cgi?foo=bar returns ajax.cgi as plaintext

This commit makes `testserver.py` parse the url properly.
