### PR TITLE
Adds support to process multi segment annotation from a tagging service

### DIFF
--- a/server/src/tag.py
+++ b/server/src/tag.py
@@ -157,14 +157,12 @@ def tag(collection, document, tagger):
             assert len(offsets) != 0, 'Tagger response has empty offsets'
             assert len(texts) == len(offsets), 'Tagger response has different numbers of offsets and texts'
 
-            # Note: We do not support discontinuous spans at this point
-            assert len(offsets) < 2, 'Tagger response has multiple offsets (discontinuous spans not supported)'
             start, end = offsets[0]
             text = texts[0]
 
             _id = ann_obj.get_new_id('T')
 
-            tb = TextBoundAnnotationWithText(((start, end),), _id, _type, text)
+            tb = TextBoundAnnotationWithText(offsets, _id, _type, text, " " + ' '.join(texts[1:]))
 
             mods.addition(tb)
             ann_obj.add_annotation(tb)


### PR DESCRIPTION
The multi segment case is now handled and all the segments are used to create the Text Bound Annotation With Text.

Its difficult to see from the code why this was not enabled in the first place, maybe there are some known issues with return multi segment annotations? Please review the change before pulling it in.
