### PR TITLE
The URL to call the remote tagging service now includes the query string

### DIFF
--- a/server/src/tag.py
+++ b/server/src/tag.py
@@ -126,7 +126,7 @@ def tag(collection, document, tagger):
                 conn.request('POST',
                         # As per: http://bugs.python.org/issue11898
                         # Force the url to be an ascii string
-                        str(url_soup.path),
+                        str(service_url),
                         data,
                         headers=req_headers)
             except SocketError, e:


### PR DESCRIPTION
Please see issue #1030 for further details. For the next pull request I will follow the suggested procedure to not create a separate issue.
