### PR TITLE
only show relevant entity attributes on initial dialog display

### DIFF
--- a/client/src/annotator_ui.js
+++ b/client/src/annotator_ui.js
@@ -886,10 +886,12 @@ var AnnotatorUI = (function($, window, undefined) {
 
         showValidAttributes = function() {
           var type = $('#span_form input:radio:checked').val();
+          
+          showAllAttributes = false;
+          
           var entityAttrCount = showAttributesFor(entityAttributeTypes, 'entity', type);
           var eventAttrCount = showAttributesFor(eventAttributeTypes, 'event', type);
           
-          showAllAttributes = false;
           // show attribute frames only if at least one attribute is
           // shown, and set size classes appropriately
           if (eventAttrCount > 0) {


### PR DESCRIPTION
Currently it seems that if you create a new text bound annotation then all possible entity attributes are shown when the dialog opens. If you change the entity type then this corrects the problem and restricts to just the relevant attributes. Moving the setting of showAllAttributes to false to before (rather than after) the calls to showAttributesFor fixes the problem (and seems to make more sense to me)
