### PR TITLE
Fixed server hang issue (lock not always released)

### DIFF
--- a/server/src/server.py
+++ b/server/src/server.py
@@ -302,7 +302,6 @@ def serve(params, client_ip, client_hostname, cookie_data):
             _config_check()
         finally:
             CONFIG_CHECK_LOCK.release()
-            raise
     except ConfigurationError, e:
         json_dic = {}
         e.json(json_dic)


### PR DESCRIPTION
When I initially installed Brat with Apache and flup, it would simply hang when I tried to load a page. This change fixed it.
