### PR TITLE
Tomcat installation instructions fixed.

### DIFF
--- a/tools/servlet/README.md
+++ b/tools/servlet/README.md
@@ -9,9 +9,11 @@ exercise.
 
 First, some words on how this works. You will attempt a WAR (Web application
 ARchive) containing a working brat installation. This means you will first
-have to install brat as usual and deploy your data. Deploy your brat
-installation in `brat/WEB-INF/cgi`, then, proving that you don't need ant to
-build something Java-ish, simply run:
+have to install brat as usual and deploy your data. Create the brat folder
+structure as shown (`brat/WEB-INF`, `brat/META-INF`) with the given web.xml and
+context.xml. Copy your previously installed brat installation to `brat/`, then, 
+proving that you don't need ant to build something Java-ish, simply go to the 
+parent folder of `brat`, where GNUmakefile is, and run:
 
     make
 

--- a/tools/servlet/brat/WEB-INF/web.xml
+++ b/tools/servlet/brat/WEB-INF/web.xml
@@ -8,7 +8,15 @@
         <servlet-class>org.apache.catalina.servlets.CGIServlet</servlet-class>
         <init-param>
             <param-name>executable</param-name>
+	    <!--The version of python used by brat. If, for example, you're 
+		running a *nix distro with a strict native python that is 
+		incompatible with brat you will want to install an alternative
+		python version and set that here.-->
             <param-value>python</param-value>
+        </init-param>
+        <init-param>
+          <param-name>cgiPathPrefix</param-name>
+          <param-value></param-value>
         </init-param>
     </servlet>
     <!-- Serve what is necessary to run brat statically
@@ -23,10 +31,12 @@
         <url-pattern>*.js</url-pattern>
         <url-pattern>*.png</url-pattern>
         <url-pattern>*.xhtml</url-pattern>
+        <url-pattern>*.ttf</url-pattern>
     </servlet-mapping>
     <!-- But serve CGI as, well, CGI. -->
     <servlet-mapping>
         <servlet-name>brat</servlet-name>
         <url-pattern>*.cgi</url-pattern>
-    </servlet-mapping> 
+    </servlet-mapping>
 </web-app>
+


### PR DESCRIPTION
The current master version of tools/servlet advises to deploy a Brat installing to WEB-INF/cgi and to create the WAR file from this structure. When deployed as such Tomcat will not be able to serve any of Brat's resources as Tomcat cannot directly serve resources inside WEB-INF, they are not publicly accessible. They're only accessible by RequestDispatcher in servlets or by <jsp:include> in JSPs.

This change simply moves the advised Brat installation directory to the root of the web application and modifies the web.xml respectively. Also, this adds a url-pattern mapping for *.ttf fonts.