### PR TITLE
Tab annotations

### DIFF
--- a/server/src/annotation.py
+++ b/server/src/annotation.py
@@ -103,7 +103,7 @@ class AnnotationCollectionNotFoundError(ProtocolError):
         # TODO: more specific error?
         json_dic['exception'] = 'annotationCollectionNotFound'
         return json_dic
-   
+
 
 class EventWithoutTriggerError(ProtocolError):
     def __init__(self, event):
@@ -115,7 +115,7 @@ class EventWithoutTriggerError(ProtocolError):
     def json(self, json_dic):
         json_dic['exception'] = 'eventWithoutTrigger'
         return json_dic
-   
+
 
 class EventWithNonTriggerError(ProtocolError):
     def __init__(self, event, non_trigger):
@@ -242,7 +242,7 @@ def is_valid_id(id):
 
     try:
         # currently accepting any ID that can be split.
-        # TODO: consider further constraints 
+        # TODO: consider further constraints
         __split_annotation_id(id)[1]
         return True
     except InvalidIdError:
@@ -258,7 +258,7 @@ class Annotations(object):
 
     def get_document(self):
         return self._document
-    
+
     def _select_input_files(self, document):
         """
         Given a document name (path), returns a list of the names of
@@ -305,14 +305,14 @@ class Annotations(object):
                     self._read_only = True
             else:
                 # Our last shot, we go for as many partial files as possible
-                input_files = [sugg_path for sugg_path in 
+                input_files = [sugg_path for sugg_path in
                         (document + '.' + suff
                             for suff in PARTIAL_ANN_FILE_SUFF)
                         if isfile(sugg_path)]
                 self._read_only = True
 
         return input_files
-            
+
     #TODO: DOC!
     def __init__(self, document, read_only=False):
         # this decides which parsing function is invoked by annotation
@@ -349,7 +349,7 @@ class Annotations(object):
         # Maximum id number used for each id prefix, to speed up id generation
         #XXX: This is effectively broken by the introduction of id suffixes
         self._max_id_num_by_prefix = defaultdict(lambda : 1)
-        # Annotation by id, not includid non-ided annotations 
+        # Annotation by id, not includid non-ided annotations
         self._ann_by_id = {}
         ###
 
@@ -372,7 +372,7 @@ class Annotations(object):
         # Finally, parse the given annotation file
         try:
             self._parse_ann_file()
-        
+
             # Sanity checking that can only be done post-parse
             self._sanity()
         except UnicodeDecodeError:
@@ -447,10 +447,10 @@ class Annotations(object):
                 if conflict_ann_ids:
                     referencer = self.get_ann_by_id(list(conflict_ann_ids)[0])
                     raise TriggerReferenceError(tr_ann, referencer)
-        
+
     def get_events(self):
         return (a for a in self if isinstance(a, EventAnnotation))
-    
+
     def get_attributes(self):
         return (a for a in self if isinstance(a, AttributeAnnotation))
 
@@ -471,7 +471,7 @@ class Annotations(object):
         triggers = [t for t in self.get_triggers()]
         return (a for a in self if (isinstance(a, TextBoundAnnotation) and
                                     not a in triggers))
-    
+
     def get_oneline_comments(self):
         #XXX: The status exception is for the document status protocol
         #       which is yet to be formalised
@@ -513,7 +513,7 @@ class Annotations(object):
                 for ent in merge_cand.entities:
                     if ent in eq_ann.entities:
                         for m_ent in merge_cand.entities:
-                            if m_ent not in eq_ann.entities: 
+                            if m_ent not in eq_ann.entities:
                                 eq_ann.entities.append(m_ent)
                         # Don't try to delete ann since it never was added
                         if merge_cand != ann:
@@ -583,7 +583,7 @@ class Annotations(object):
             soft_deps, hard_deps = other_ann.get_deps()
             if unicode(ann.id) in soft_deps | hard_deps:
                 ann_deps.append(other_ann)
-              
+
         # If all depending are AttributeAnnotations or EquivAnnotations,
         # delete all modifiers recursively (without confirmation) and remove
         # the annotation id from the equivs (and remove the equiv if there is
@@ -630,7 +630,7 @@ class Annotations(object):
                     # covered above.
                     assert False, "INTERNAL ERROR"
             ann_deps = []
-            
+
         if ann_deps:
             raise DependingAnnotationDeleteError(ann, ann_deps)
 
@@ -659,7 +659,7 @@ class Annotations(object):
         # Update the modification time
         from time import time
         self.ann_mtime = time()
-    
+
     def get_ann_by_id(self, id):
         #TODO: DOC
         try:
@@ -709,7 +709,7 @@ class Annotations(object):
             if match is None:
                 raise IdedAnnotationLineSyntaxError(id, self.ann_line,
                         self.ann_line_num + 1, input_file_path)
-                
+
             _type, target = match.groups()
             value = True
         else:
@@ -755,7 +755,7 @@ class Annotations(object):
         except ValueError:
             # cannot have a relation with just a type (contra event)
             raise IdedAnnotationLineSyntaxError(id, self.ann_line, self.ann_line_num+1, input_file_path)
-            
+
         try:
             args = [tuple(arg.split(':')) for arg in type_tail.split()]
         except ValueError:
@@ -830,7 +830,7 @@ class Annotations(object):
                 if d != data:
                     data = d
                     break
-            
+
         match = re_match(r'(\S+) (\S+) (\S+?):(\S+)', data)
         if match is None:
             raise IdedAnnotationLineSyntaxError(_id, self.ann_line, self.ann_line_num + 1, input_file_path)
@@ -844,7 +844,7 @@ class Annotations(object):
         except ValueError:
             raise IdedAnnotationLineSyntaxError(_id, self.ann_line, self.ann_line_num+1, input_file_path)
         return OnelineCommentAnnotation(target, _id, _type, data_tail, source_id=input_file_path)
-    
+
     def _parse_ann_file(self):
         self.ann_line_num = -1
         for input_file_path in self._input_files:
@@ -935,7 +935,7 @@ class Annotations(object):
     def __enter__(self):
         # No need to do any handling here, the constructor handles that
         return self
-    
+
     def __exit__(self, type, value, traceback):
         #self._file_input.close()
         if not self._read_only:
@@ -944,7 +944,7 @@ class Annotations(object):
             # We are hitting the disk a lot more than we should here, what we
             # should have is a modification flag in the object but we can't
             # due to how we change the annotations.
-            
+
             out_str = unicode(self)
             with open_textfile(self._input_files[0], 'r') as old_ann_file:
                 old_str = old_ann_file.read()
@@ -955,7 +955,7 @@ class Annotations(object):
                 return
 
             from config import WORK_DIR
-            
+
             # Protect the write so we don't corrupt the file
             with file_lock(path_join(WORK_DIR,
                     str(hash(self._input_files[0].replace('/', '_')))
@@ -1025,7 +1025,7 @@ class TextAnnotations(Annotations):
                 textfile_path = document[:len(document) - len(file_ext)]
 
         self._document_text = self._read_document_text(textfile_path)
-        
+
         Annotations.__init__(self, document, read_only)
 
     def _parse_textbound_annotation(self, id, data, data_tail, input_file_path):
@@ -1055,7 +1055,7 @@ class TextAnnotations(Annotations):
         spanlen = sum([end-start for start, end in spans]) + (len(spans)-1)*len(DISCONT_SEP)
 
         # Require tail to be either empty or to begin with the text
-        # corresponding to the catenation of the start:end spans. 
+        # corresponding to the catenation of the start:end spans.
         # If the tail is empty, force a fill with the corresponding text.
         if data_tail.strip() == '' and spanlen > 0:
             Messager.error(u"Text-bound annotation missing text (expected format 'ID\\tTYPE START END\\tTEXT'). Filling from reference text. NOTE: This changes annotations on disk unless read-only.")
@@ -1125,7 +1125,7 @@ class Annotation(object):
 
     def __repr__(self):
         return u'%s("%s")' % (unicode(self.__class__), unicode(self))
-    
+
     def get_deps(self):
         return (set(), set())
 
@@ -1280,7 +1280,7 @@ class EquivAnnotation(TypedAnnotation):
     other annotations (normally TextBoundAnnotation) to be equivalent.
 
     Represented in standoff as
-    
+
     *\tTYPE ID1 ID2 [...]
 
     Where "*" is the literal asterisk character.
@@ -1323,7 +1323,7 @@ class AttributeAnnotation(IdedAnnotation):
         IdedAnnotation.__init__(self, id, type, tail, source_id=source_id)
         self.target = target
         self.value = value
-        
+
     def __str__(self):
         return u'%s\t%s %s%s%s' % (
                 self.id,
@@ -1377,7 +1377,7 @@ class OnelineCommentAnnotation(IdedAnnotation):
     def __init__(self, target, id, type, tail, source_id=None):
         IdedAnnotation.__init__(self, id, type, tail, source_id=source_id)
         self.target = target
-        
+
     def __str__(self):
         return u'%s\t%s %s%s' % (
                 self.id,
@@ -1405,7 +1405,7 @@ class TextBoundAnnotation(IdedAnnotation):
     TextBoundAnnotationWithText for that.
 
     Represented in standoff as
-    
+
     ID\tTYPE START END
 
     Where START and END are positive integer offsets identifying the
@@ -1567,7 +1567,7 @@ class BinaryRelationAnnotation(IdedAnnotation):
             self.arg2,
             self.tail
             )
-    
+
     def get_deps(self):
         soft_deps, hard_deps = IdedAnnotation.get_deps(self)
         hard_deps.add(self.arg1)

--- a/server/src/annotator.py
+++ b/server/src/annotator.py
@@ -33,10 +33,6 @@ from jsonwrap import loads as json_loads, dumps as json_dumps
 from message import Messager
 from projectconfig import ProjectConfiguration, ENTITY_CATEGORY, EVENT_CATEGORY, RELATION_CATEGORY, UNKNOWN_CATEGORY
 
-### Constants
-MUL_NL_REGEX = re_compile(r'\n+')
-###
-
 #TODO: Couldn't we incorporate this nicely into the Annotations class?
 #TODO: Yes, it is even gimped compared to what it should do when not. This
 #       has been a long pending goal for refactoring.

--- a/tools/annalign.py
+++ b/tools/annalign.py
@@ -25,17 +25,17 @@ def argparser():
     import argparse
 
     ap=argparse.ArgumentParser(description="Align text and annotations to different version of same text.")
-    ap.add_argument(TEST_ARG, default=False, action="store_true", 
+    ap.add_argument(TEST_ARG, default=False, action="store_true",
                     help="Perform self-test and exit")
     ap.add_argument('-e', '--encoding', default=DEFAULT_ENCODING,
                     help='text encoding (default %s)' % DEFAULT_ENCODING)
-    ap.add_argument('-v', '--verbose', default=False, action="store_true", 
+    ap.add_argument('-v', '--verbose', default=False, action="store_true",
                     help="Verbose output")
-    ap.add_argument("ann", metavar="ANN", nargs=1, 
+    ap.add_argument("ann", metavar="ANN", nargs=1,
                     help="Annotation file")
-    ap.add_argument("oldtext", metavar="OLD-TEXT", nargs=1, 
+    ap.add_argument("oldtext", metavar="OLD-TEXT", nargs=1,
                     help="Text matching annotation")
-    ap.add_argument("newtext", metavar="NEW-TEXT", nargs=1, 
+    ap.add_argument("newtext", metavar="NEW-TEXT", nargs=1,
                     help="Text to align to")
     return ap
 
@@ -92,6 +92,7 @@ class Textbound(Annotation):
         # Remapping may create spans that extend over newlines, which
         # brat doesn't handle well. Break any such span into multiple
         # fragments that skip newlines.
+        # TODO: Update this to handle tabs?
         fragmented = []
         for start, end in self.offsets:
             while start < end:
@@ -118,13 +119,13 @@ class Textbound(Annotation):
             print >> sys.stderr, 'Warning: newline in text: %s' % self.text
 
     def __unicode__(self):
-        return u"%s\t%s %s\t%s" % (self.id_, self.type_, 
+        return u"%s\t%s %s\t%s" % (self.id_, self.type_,
                                   ';'.join(['%d %d' % (s, e)
                                             for s, e in self.offsets]),
                                   escape_tb_text(self.text))
 
     def __str__(self):
-        return "%s\t%s %s\t%s" % (self.id_, self.type_, 
+        return "%s\t%s %s\t%s" % (self.id_, self.type_,
                                   ';'.join(['%d %d' % (s, e)
                                             for s, e in self.offsets]),
                                   escape_tb_text(self.text))
@@ -135,10 +136,10 @@ class XMLElement(Textbound):
         self.attributes = attributes
 
     def __str__(self):
-        return "%s\t%s %s\t%s\t%s" % (self.id_, self.type_, 
+        return "%s\t%s %s\t%s\t%s" % (self.id_, self.type_,
                                       ';'.join(['%d %d' % (s, e)
                                                 for s, e in self.offsets]),
-                                      escape_tb_text(self.text), 
+                                      escape_tb_text(self.text),
                                       self.attributes)
 
 class ArgAnnotation(Annotation):
@@ -159,7 +160,7 @@ class Event(ArgAnnotation):
         self.trigger = trigger
 
     def __str__(self):
-        return "%s\t%s:%s %s" % (self.id_, self.type_, self.trigger, 
+        return "%s\t%s:%s %s" % (self.id_, self.type_, self.trigger,
                                  ' '.join(self.args))
 
 class Attribute(Annotation):
@@ -169,7 +170,7 @@ class Attribute(Annotation):
         self.value = value
 
     def __str__(self):
-        return "%s\t%s %s%s" % (self.id_, self.type_, self.target, 
+        return "%s\t%s %s%s" % (self.id_, self.type_, self.target,
                                 '' if self.value is None else ' '+self.value)
 
 class Normalization(Annotation):
@@ -277,7 +278,7 @@ def parse(l, ln):
 def parseann(fn):
     global options
 
-    annotations = []    
+    annotations = []
     with codecs.open(fn, 'rU', encoding=options.encoding) as f:
         lines = [l.rstrip('\n') for l in f.readlines()]
 
@@ -324,7 +325,7 @@ def match_cost(a, b):
             return 0
         else:
             return -1000
-    
+
 def space_boundary(s, i):
     if (i == 0 or s[i-1].isspace() != s[i].isspace() or
         i+1 == len(s) or s[i+1].isspace() != s[i].isspace()):
@@ -334,7 +335,7 @@ def space_boundary(s, i):
 
 CH_OUT, CH_MATCH, CH_DELETE, CH_SPC_DELETE, CH_INSERT, CH_SPC_INSERT = range(6)
 
-def delete_cost(A, B, i, j, choices):   
+def delete_cost(A, B, i, j, choices):
     if choices[i-1][j] == CH_DELETE:
         # standard gap extend
         return -1, CH_DELETE
@@ -371,7 +372,7 @@ def swchoice(A, B, i, j, F, choices):
 
     best = max(match, delete, insert, 0)
 
-    if best == match:        
+    if best == match:
         choice = CH_MATCH
         if DEBUG and A[i-1] != B[j-1]:
             print >> sys.stderr, "MISMATCH! '%s' vs '%s'" % (A[i-1], B[j-1])
@@ -635,7 +636,7 @@ class Remapper(object):
             return offset_map[start], offset_map[end]
         else:
             return self.offset_map[start], self.offset_map[end-1]+1
-        
+
 def test():
     import doctest
     doctest.testmod()


### PR DESCRIPTION
Previously, attempting to make an annotation spanning newlines with multiple fragments would behave unreliably, and sometimes cause data corruption. This is now fixed. Additionally, I extended the same discontinuous span technique used to solve #786 to solve #819, adding support for annotations spanning tabs. (Arguably, proper escaping would still be a more elegant solution.)

Unresolved issue: when virtual fragments are created to handle line splits and tabs, deleting/moving a virtual fragment deletes only that one small chunk. It does not delete anything beyond the nearest newline or tab, which may mean part of the larger fragment the user meant to delete still remains.

(Apologies for all the distracting whitespace deletions from editing in Emacs.)
