### PR TITLE
Synonyms in norm serch result

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,5 @@ config.py
 # Standard locations of data and server temporary files
 data/
 work/
+
+.idea/

--- a/config_template.py
+++ b/config_template.py
@@ -86,6 +86,9 @@ DEBUG = False
 # Unauthorised users can create tutorials (but not edit without a login)
 TUTORIALS = False
 
+### NORMALIZATION
+SHOW_SYNONYMS = False
+
 ### LOG_LEVEL
 # If you are a developer you may want to turn on extensive server
 # logging by enabling LOG_LEVEL = LL_DEBUG

--- a/server/src/norm.py
+++ b/server/src/norm.py
@@ -34,6 +34,12 @@ NORM_LOOKUP_DEBUG = True
 
 REPORT_LOOKUP_TIMINGS = False
 
+try:
+    from config import SHOW_SYNONYMS
+except ImportError:
+    # unlimited
+    SHOW_SYNONYMS = False
+
 # debugging
 def _check_DB_version(database):
     # TODO; not implemented yet for new-style SQL DBs.
@@ -221,9 +227,10 @@ def _format_datas(datas, scores=None, matched=None):
                                               data_dict[label] not in matched):
                     data_dict[label] = value
                 else:
-                    syn_label = "%s Synonyms" % label
-                    data_dict.setdefault(syn_label,[]).append(value)
-                    extra_labels[syn_label] = True
+                    if SHOW_SYNONYMS:
+                        syn_label = "%s Synonyms" % label
+                        data_dict.setdefault(syn_label,[]).append(value)
+                        extra_labels[syn_label] = True
         # construct item
         item = [str(key)]
         for label in unique_labels:
@@ -234,16 +241,16 @@ def _format_datas(datas, scores=None, matched=None):
                 item.append(value)
             else:
                 item.append('')
+        if SHOW_SYNONYMS:
+            for label in extra_labels:
+                if label in data_dict:
+                    value = data_dict[label]
+                    if isinstance(value, list):
+                        value = " | ".join(value)
+                    item.append(value)
+                else:
+                    item.append('')
 
-        for label in extra_labels:
-            if label in data_dict:
-                value = data_dict[label]
-                if isinstance(value, list):
-                    value = " | ".join(value)
-                item.append(value)
-            else:
-                item.append('')
-        
         if DISPLAY_SEARCH_SCORES:
             item += [str(scores.get(key))]
 

--- a/server/src/norm.py
+++ b/server/src/norm.py
@@ -515,19 +515,23 @@ def _test():
             delta = datetime.now() - start
             found = False
             found_rank = -1
+            has_synonym = False
             for rank, item in enumerate(results['items']):
                 id_ = item[0]
                 if id_ == target:
                     found = True
                     found_rank = rank+1
+                    if len(item) >= 2:
+                        has_synonym = True
                     break
             strdelta = str(delta).replace('0:00:0','').replace('0:00:','')
-            print "%s: '%s' <- '%s' rank %d/%d (%s sec)" % ('  ok' if found 
+            print "%s: '%s' <- '%s' rank %d/%d (%s sec) %s" % ('  ok' if found 
                                                             else 'MISS',
                                                             target, query, 
                                                             found_rank,
                                                             len(results['items']),
-                                                            strdelta)
+                                                            strdelta,
+                                                            ' has Synonym(s)' if has_synonym else '')
             query_count += 1
             if found:
                 hit_count += 1
@@ -554,5 +558,9 @@ def _profile_test():
     cProfile.run('_test()', 'norm.profile')
 
 if __name__ == '__main__':
+    SHOW_SYNONYMS=False
     _test() # normal
+    print '  ### SWITCH SYNONYMS ON ###  '
+    SHOW_SYNONYMS=True
+    _test()
     #_profile_test() # profiled

--- a/server/src/norm.py
+++ b/server/src/norm.py
@@ -236,8 +236,6 @@ def _format_datas(datas, scores=None, matched=None):
         for label in unique_labels:
             if label in data_dict:
                 value = data_dict[label]
-                if isinstance(value, list):
-                    value = " | ".join(value)
                 item.append(value)
             else:
                 item.append('')


### PR DESCRIPTION
When using the normalization plugin annotators find it hard to distinguish between database entires when only the name and the id is present. Synonyms (other name fields in the database) can help them.

This PR makes it possible to show all the synonyms on the UI in the normalization search result dialog.

The setting `SHOW_SYNONYMS ` in the config can switch the feature on. It is set to `False` by default so users have to switch it on to use the new functionality.

