### PR TITLE
fix(login): added hashing for passwords

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -62,7 +62,8 @@ else
 	echo "Please enter a brat password (this shows on screen):"
 	read password
 	if [ -n "$password" ]; then
-	    break
+        password=$(python -c 'from hashlib import pbkdf2_hmac; from base64 import b64encode; print b64encode(pbkdf2_hmac("sha256", u"'$password'".encode("utf-8"), u"'$user_name'".encode("utf-8"), 30000))')
+        break
 	fi
     done
     echo "Please enter the administrator contact email:"

--- a/new_user.sh
+++ b/new_user.sh
@@ -1,0 +1,20 @@
+#!/bin/sh
+
+while true; do
+echo 'Please enter the new user name that you want to use when logging into brat:'
+read user_name
+if [ -n "$user_name" ]; then
+    break
+fi
+done
+while true; do
+echo "Please enter a brat password (this shows on screen):"
+read password
+if [ -n "$password" ]; then
+    password=$(python -c 'from hashlib import pbkdf2_hmac; from base64 import b64encode; print b64encode(pbkdf2_hmac("sha256", u"'$password'".encode("utf-8"), u"'$user_name'".encode("utf-8"), 30000))')
+    break
+fi
+done
+
+echo "Place the following line in USER_PASSWORD in the config.py file"
+echo "'$user_name': '$password',"

--- a/server/src/auth.py
+++ b/server/src/auth.py
@@ -10,7 +10,8 @@ Author:     Pontus Stenetorp    <pontus is s u-tokyo ac jp>
 Version:    2011-04-21
 '''
 
-from hashlib import sha512
+from hashlib import pbkdf2_hmac
+from base64 import b64encode
 from os.path import dirname, join as path_join, isdir
 
 try:
@@ -68,11 +69,12 @@ class InvalidAuthError(ProtocolError):
 def _is_authenticated(user, password):
     # TODO: Replace with a database back-end
     return (user in USER_PASSWORD and
-            password == USER_PASSWORD[user])
-            #password == _password_hash(USER_PASSWORD[user]))
+            #password == USER_PASSWORD[user])
+            #TODO: generate randomly and store salts, instead of using the username string
+            USER_PASSWORD[user] == _password_hash(user, password))
 
-def _password_hash(password):
-    return sha512(password).hexdigest()
+def _password_hash(user, password):
+    return b64encode(pbkdf2_hmac('sha256', password.encode('utf-8'), user.encode('utf-8'), 30000))
 
 def login(user, password):
     if not _is_authenticated(user, password):


### PR DESCRIPTION
Storing passwords in plaintext is a security risk,
the proper way to store passwords is to store
only the hash value of the password.
Hash functions such as SHA are general purpose,
other solutions like pbkdf2 offer more security by
making the hash procedure much more computationally
intensive, preventing some attacks.