### PR TITLE
Fix selection highlight in Chrome (#1288)

### DIFF
--- a/client/src/fix-chrome-svg-selection-highlight.js
+++ b/client/src/fix-chrome-svg-selection-highlight.js
@@ -1,0 +1,22 @@
+// Chrome bug: https://bugs.chromium.org/p/chromium/issues/detail?id=897752
+
+(function() {
+    var isChrome = !!window.chrome && !!window.chrome.webstore;
+    if (!isChrome) return;
+
+    // check Chrome version
+    var chromeVersionRe = /Chrome\/(\d+)\./;
+    var m = window.navigator.userAgent.match(chromeVersionRe);
+    if (!m) return;
+
+    var chromeVersion = parseInt(m[1]);
+    if (chromeVersion < 70) return; // bug appears in Chrome v70.*
+
+    // highlight the selection with red-colored text
+    var cssRule = 'svg tspan::selection {fill: red; background: none;}';
+
+    var style = window.document.createElement('style');
+    window.document.head.appendChild(style);
+
+    style.sheet.insertRule(cssRule, 0);
+})();

--- a/index.xhtml
+++ b/index.xhtml
@@ -33,7 +33,8 @@
           'client/src/visualizer.js',
           'client/src/visualizer_ui.js',
           'client/src/annotator_ui.js',
-          'client/src/spinner.js'
+          'client/src/spinner.js',
+          'client/src/fix-chrome-svg-selection-highlight.js'
       );
       head.ready(function() {
           // var dispatcher = new Dispatcher(); // XXX DEBUG


### PR DESCRIPTION
Issue #1288
Chrome bug: https://bugs.chromium.org/p/chromium/issues/detail?id=904543

This bug already fixed but patch will appears in stable Chrome only at the end of Jan19.
During this time I suggest to use little CSS trick - replace default selection highlight with red-colored text.

I added JS code which apply this CSS rule only for Chrome v70+.

![red-text-highlight](https://user-images.githubusercontent.com/1709886/49143978-d0af6180-f32e-11e8-8fff-70f80f1a3184.gif)

