### PR TITLE
fix word with accents being split by tokenization

### DIFF
--- a/tools/anntoconll.py
+++ b/tools/anntoconll.py
@@ -114,7 +114,7 @@ def attach_labels(labels, lines):
 # NERsuite tokenization: any alnum sequence is preserved as a single
 # token, while any non-alnum character is separated into a
 # single-character token. TODO: non-ASCII alnum.
-TOKENIZATION_REGEX = re.compile(r'([0-9a-zA-Z]+|[^0-9a-zA-Z])')
+TOKENIZATION_REGEX = re.compile(r'([0-9a-zA-ZÀ-ÿ]+|[^0-9a-zA-ZÀ-ÿ])')
 
 NEWLINE_TERM_REGEX = re.compile(r'(.*?\n)')
 


### PR DESCRIPTION
 In the current version, the anntoconll tool will split a word containing accents into different tokens, isolating the accents as if they were words.  When working with european languages such as French, Spanish, etc or even German with the ß this comes to be a problem.

For example, the text "déjà fait" would be split into tokens "d", "é", "j", "à", "fait" instead of "déjà", "fait"

By adding all accents range À-ÿ to the tokenization regex, this tokenization issue doesn't happen anymore.