### PR TITLE
Update visualizer_ui.js

### DIFF
--- a/client/src/visualizer_ui.js
+++ b/client/src/visualizer_ui.js
@@ -1448,7 +1448,12 @@ var VisualizerUI = (function($, window, undefined) {
       $('#rapid_model').addClass('ui-widget ui-state-default ui-button-text');
 
       var fillDisambiguatorOptions = function(disambiguators) {
-        $('#annotation_speed3').button(disambiguators.length ? 'enable': 'disable');
+        //begin 2019.7.19: this is to compatible with jquery3.4.0
+        //$('#annotation_speed3').button(disambiguators.length ? 'enable': 'disable');
+        $('#annotation_speed3').button();
+        var btnEnable = disambiguators.length ? 'enable': 'disable' ;
+        $('#annotation_speed3').button(btnEnable);
+        //end 2019.7.19
         //XXX: We need to disable rapid in the conf too if it is not available
         var $rapid_mode = $('#rapid_model').html('');
         $.each(disambiguators, function(modelNo, model) {


### PR DESCRIPTION
To work with jquery-3.4.0.min.js:

client/lib/jquery.min.js: 1.11.2-->1.12.1 (http://jquery.com)
client/lib/jquery-ui.min.js: 2.1.1-->3.4.0 (http://jqueryui.com)

brat/client/src/visualizer_ui.js: line 1451:
---- $('#annotation_speed3').button(disambiguators.length ? 'enable': 'disable');
++++ $('#annotation_speed3').button();
++++ var btnEnable = disambiguators.length ? 'enable': 'disable' ;
++++ $('#annotation_speed3').button(btnEnable);

Then, it passed.