### PR TITLE
Fix case where multiple spans are covered by a single entity

### DIFF
--- a/tools/anntoconll.py
+++ b/tools/anntoconll.py
@@ -262,10 +262,11 @@ def parse_textbounds(f):
             continue
 
         id_, type_offsets, text = l.split('\t')
-        type_, start, end = type_offsets.split()
-        start, end = int(start), int(end)
-
-        textbounds.append(Textbound(start, end, type_, text))
+        offsets = ' '.join(type_offsets.split()[1:]).split(';')
+        for offset in offsets:
+            start = int(offset.split()[0])
+            end = int(offset.split()[1])
+            textbounds.append(Textbound(start, end, type_, text))
 
     return textbounds
 


### PR DESCRIPTION
In brat ann files, sometimes, multiple spans of text are covered by a single entity. These are formatted by using a `;`, for example:

```
T1	E1 77 128	some text
T2	E2 7 75	some other text
T3	E3 148 346;347 354	some other some other text
```

The tool that converts `ann` files to CONLL format fails to handle this case.