### PR TITLE
fix: file open mode fixed to w

### DIFF
--- a/tools/conllXtostandoff.py
+++ b/tools/conllXtostandoff.py
@@ -68,8 +68,8 @@ def output(infn, docnum, sentences):
         else:
             outfnbase = os.path.basename(infn)
         outfn = os.path.join(output_directory, outfnbase)
-        txtout = codecs.open(outfn + '.txt', 'wt', encoding=OUTPUT_ENCODING)
-        soout = codecs.open(outfn + '.ann', 'wt', encoding=OUTPUT_ENCODING)
+        txtout = codecs.open(outfn + '.txt', 'w', encoding=OUTPUT_ENCODING)
+        soout = codecs.open(outfn + '.ann', 'w', encoding=OUTPUT_ENCODING)
 
     offset, idnum, ridnum = 0, 1, 1
 


### PR DESCRIPTION
`conllXtostandoff.py` was using an incorrect mode to create output files.
It resulted in:
```
python3 tools/conllXtostandoff.py -o test data/UD_Turkish-IMST/tr_imst-ud-test.conllu
Writing output to test
Error processing data/UD_Turkish-IMST/tr_imst-ud-test.conllu: b"can't have text and binary mode at once"

##############################################################################
#
# WARNING: error in processing 1/1 files, output is incomplete!
#
##############################################################################
```