### PR TITLE
fix bugs on cannot expand the drop-down box in event type window

### DIFF
--- a/client/src/annotator_ui.js
+++ b/client/src/annotator_ui.js
@@ -2064,7 +2064,7 @@ var AnnotatorUI = (function($, window, undefined) {
       var collapseHandler = function(evt) {
         toggleCollapsible($(evt.target));
       }
-      $('#arc_roles, #entity_types').on('click', '.collapser', collapseHandler);
+      $('#arc_roles, #entity_types, #event_types').on('click', '.collapser', collapseHandler);
 
       var spanFormSubmitRadio = function(evt) {
         if (Configuration.confirmModeOn) {


### PR DESCRIPTION
there is a bug:
when event type has too much multi-hierarchy structure,
we cannot click the "+" button to expand the the drop-down box.

this is going to fix this.